### PR TITLE
support output type loglikelihood and loglikelihood_rolling

### DIFF
--- a/lm_eval/models/sglang_causallms.py
+++ b/lm_eval/models/sglang_causallms.py
@@ -83,7 +83,6 @@ class SGLangLM(TemplateLM):
             "trust_remote_code": trust_remote_code,
             "dtype": dtype,
             "kv_cache_dtype": kv_cache_dtype,
-            "context_length": int(self._max_length) + 7 if self._max_length else None,
             "device": device,
             "mem_fraction_static": mem_fraction_static,
             "tp_size": self.tensor_parallel_size,
@@ -92,7 +91,6 @@ class SGLangLM(TemplateLM):
         }
 
         self.model_args.update(kwargs)
-        server_args = ServerArgs(**self.model_args)
         self.batch_size = (
             "auto"
             if isinstance(batch_size, str) and "auto" in batch_size

--- a/lm_eval/models/sglang_causallms.py
+++ b/lm_eval/models/sglang_causallms.py
@@ -56,6 +56,7 @@ class SGLangLM(TemplateLM):
         # parallelism
         dp_size: int = 1,
         tp_size: int = 1,
+        prefix_token_id: Optional[int] = None,
         **kwargs
     ):
         super().__init__()
@@ -82,7 +83,7 @@ class SGLangLM(TemplateLM):
             "trust_remote_code": trust_remote_code,
             "dtype": dtype,
             "kv_cache_dtype": kv_cache_dtype,
-            "context_length": int(self._max_length) if self._max_length else None,
+            "context_length": int(self._max_length) + 7 if self._max_length else None,
             "device": device,
             "mem_fraction_static": mem_fraction_static,
             "tp_size": self.tensor_parallel_size,
@@ -114,12 +115,76 @@ class SGLangLM(TemplateLM):
             eval_logger.info(
                 "Found 'gemma' in model name, a BOS token will be used as Gemma series models underperform without it."
             )
+        self.custom_prefix_token_id = prefix_token_id
 
-    def loglikelihood_rolling(self, requests: List[Instance]) -> List[float]:
-        # Implement rolling loglikelihood calculation
-        # Return [log_prob, ...]
-        mocked = [0.0] * len(requests)
-        return mocked
+    def loglikelihood_rolling(
+        self, requests: List[Instance], disable_tqdm: bool = False
+    ) -> List[float]:
+        adaptive_batch_size = None
+        if self.batch_size == "auto":
+            adaptive_batch_size = len(requests)
+
+        # First, collect all windows from all requests
+        all_windows = []  # List of (request_idx, window) tuples
+        request_window_counts = []  # Track number of windows per request
+
+        for req_idx, (string,) in enumerate(
+            tqdm(
+                [req.args for req in requests],
+                disable=(disable_tqdm or (self.rank != 0)),
+            )
+        ):
+            rolling_token_windows: List[Tuple[List[int], List[int]]] = list(
+                map(
+                    make_disjoint_window,
+                    get_rolling_token_windows(
+                        token_list=self.tok_encode(string),
+                        prefix_token=self.prefix_token_id,
+                        # max_seq_len - (1 for context)
+                        max_seq_len=self.max_length - 1,
+                        context_len=1,
+                    ),
+                )
+            )
+
+            # TODO: Right now, we pass single EOT token to the Encoder and the full context to the decoder, in seq2seq case
+            windows = [(None,) + x for x in rolling_token_windows]
+
+            # Store windows with their request index
+            all_windows.extend((req_idx, window) for window in windows)
+            request_window_counts.append(len(windows))
+
+        all_nlls = []
+        batch_size = adaptive_batch_size or int(self.batch_size)
+        for i in range(0, len(all_windows), batch_size):
+            batch = all_windows[i : i + batch_size]
+            # Extract just the windows for processing, keeping track of request indices
+            batch_indices, batch_windows = zip(*batch)
+
+            batch_nlls = self._loglikelihood_tokens(
+                requests=batch_windows,
+                disable_tqdm=False,
+            )
+            # Store results with their request indices
+            all_nlls.extend(zip(batch_indices, batch_nlls))
+
+        # Reconstruct per-request loglikelihoods
+        loglikelihoods = []
+        current_idx = 0
+        for window_count in request_window_counts:
+            # Get all nlls for this request
+            request_nlls = all_nlls[current_idx : current_idx + window_count]
+            # Sum up the nlls for this request (discarding is_greedy)
+            request_total = sum(nll[0] for _, nll in request_nlls)
+            loglikelihoods.append(request_total)
+            current_idx += window_count
+
+            string = requests[len(loglikelihoods) - 1].args[0]
+            self.cache_hook.add_partial(
+                "loglikelihood_rolling", (string,), request_total
+            )
+
+        return loglikelihoods
 
     def generate_until(
         self, requests: List[Instance], disable_tqdm: bool = False
@@ -243,7 +308,7 @@ class SGLangLM(TemplateLM):
             return_logprob = return_logprob,
             top_logprobs_num = top_logprobs_num,
             logprob_start_len = logprob_start_len
-        )
+        )            
         return outputs
     
     @property

--- a/lm_eval/models/sglang_causallms.py
+++ b/lm_eval/models/sglang_causallms.py
@@ -50,6 +50,7 @@ class SGLangLM(TemplateLM):
         kv_cache_dtype: str = "auto",
         context_length: Optional[int] = None,
         device: str = "cuda",
+        chunked_prefill_size: int = -1,
         # Memory and scheduling
         mem_fraction_static: Optional[float] = None,
         # parallelism
@@ -86,6 +87,7 @@ class SGLangLM(TemplateLM):
             "mem_fraction_static": mem_fraction_static,
             "tp_size": self.tensor_parallel_size,
             "dp_size": self.data_parallel_size,
+            "chunked_prefill_size": chunked_prefill_size
         }
 
         self.model_args.update(kwargs)
@@ -113,22 +115,12 @@ class SGLangLM(TemplateLM):
                 "Found 'gemma' in model name, a BOS token will be used as Gemma series models underperform without it."
             )
 
-
-    def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
-        # Implement loglikelihood calculation
-        # Return [(log_prob, is_greedy), ...]
-        mocked = [(0.0, True)] * len(requests)
-        return mocked
-
     def loglikelihood_rolling(self, requests: List[Instance]) -> List[float]:
         # Implement rolling loglikelihood calculation
         # Return [log_prob, ...]
         mocked = [0.0] * len(requests)
         return mocked
 
-    def _loglikelihood_tokens(self, requests, disable_tqdm: bool = False):
-        raise NotImplementedError("No support for logits.")
-    
     def generate_until(
         self, requests: List[Instance], disable_tqdm: bool = False
     ) -> List[str]:
@@ -222,6 +214,9 @@ class SGLangLM(TemplateLM):
         generate: bool = False,
         max_tokens: int = None,
         stop: Optional[List[str]] = None,
+        return_logprob: bool = False,
+        top_logprobs_num: int = 1,
+        logprob_start_len: int = -1,
         **kwargs,
     ):  
         # check sglang sampling parammeters: https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/sampling/sampling_params.py#L21  and https://docs.sglang.ai/references/sampling_params.html.
@@ -245,7 +240,9 @@ class SGLangLM(TemplateLM):
         outputs = self.model.generate(
             input_ids=requests,
             sampling_params=sampling_params,
-            
+            return_logprob = return_logprob,
+            top_logprobs_num = top_logprobs_num,
+            logprob_start_len = logprob_start_len
         )
         return outputs
     
@@ -254,6 +251,15 @@ class SGLangLM(TemplateLM):
         # Return the EOT (End of Text) token ID
         return self.tokenizer.eos_token_id
 
+    @property
+    def prefix_token_id(self):
+        # it is used as prefix for loglikelihood
+        if self.custom_prefix_token_id is not None:
+            return self.custom_prefix_token_id
+        if self.tokenizer.bos_token_id is not None:
+            return self.tokenizer.bos_token_id
+        return self.tokenizer.eos_token_id
+    
     @property
     def max_length(self):
         if self._max_length:  # if max length manually set, return it
@@ -342,6 +348,95 @@ class SGLangLM(TemplateLM):
         )
 
         return chat_templated
+
+    def _loglikelihood_tokens(
+        self,
+        requests: List[Tuple[Tuple[str, str], List[int], List[int]]],
+        disable_tqdm: bool = False,
+    ) -> List[Tuple[float, bool]]:
+        res = []
+
+        def _collate(x):
+            toks = x[1] + x[2]
+            return -len(toks), tuple(toks)
+
+        # Reorder requests by length and batch
+        re_ord = Collator(requests, sort_fn=_collate)
+        chunks = re_ord.get_batched(
+            n=int(self.batch_size) if self.batch_size != "auto" else 0, batch_fn=None
+        )
+        pbar = tqdm(
+            total=len(requests),
+            disable=disable_tqdm,
+            desc="Running loglikelihood requests",
+        )
+        for chunk in chunks:
+            inputs = []
+            ctxlens = []
+            for cache_key, context_enc, continuation_enc in chunk:
+                inp = (context_enc + continuation_enc)[-(self.max_length) :]
+                ctxlen = len(context_enc) - max(
+                    0, len(context_enc) + len(continuation_enc) - (self.max_length)
+                )
+
+                inputs.append(inp)
+                ctxlens.append(ctxlen)
+
+            outputs = self._model_generate(requests=inputs, generate=False, return_logprob=True, top_logprobs_num=2, logprob_start_len=0)
+            for output, ctxlen, (cache_key, _, _), inp in zip(
+                outputs, ctxlens, chunk, inputs
+            ):
+                answer = self._parse_logprobs(
+                    tokens=inp,
+                    outputs=output,
+                    ctxlen=ctxlen,
+                )
+                res.append(answer)
+
+                if cache_key is not None:
+                    # special case: loglikelihood_rolling produces a number of loglikelihood requests
+                    # all with cache key None. instead do add_partial on the per-example level
+                    # in the loglikelihood_rolling() function for those.
+                    self.cache_hook.add_partial("loglikelihood", cache_key, answer)
+                pbar.update(1)
+        pbar.close()
+        return re_ord.get_original(res)
+
+    @staticmethod
+    def _parse_logprobs(tokens: List, outputs, ctxlen: int) -> Tuple[float, bool]:
+        """Process logprobs and tokens.
+
+        :param tokens: list
+            Input tokens (potentially left-truncated)
+        :param outputs: 
+            Contains input_token_logprobs and input_top_logprobs
+        :param ctxlen: int
+            Length of context (so we can slice them away and only keep the predictions)
+        :return:
+            continuation_logprobs: float
+                Log probabilities of continuation tokens
+            is_greedy: bool
+                Whether argmax matches given continuation exactly
+        """
+
+        # The first entry of prompt_logprobs is None because the model has no previous tokens to condition on.
+        # [(logprob, token_id, token_text)]
+        continuation_logprobs_lists = outputs['meta_info']['input_token_logprobs']
+        continuation_logprobs = sum(logprob for logprob, _, _ in continuation_logprobs_lists[ctxlen:])
+
+        top_logprobs_lists = outputs['meta_info']['input_top_logprobs']
+
+        # Determine if is_greedy
+        is_greedy = True
+        for token, top_logprobs in zip(
+            tokens[ctxlen:], top_logprobs_lists[ctxlen:]
+        ):
+            if top_logprobs:
+                top_token = max(top_logprobs, key=lambda x: x[0])[1]
+                if top_token != token:
+                    is_greedy = False
+                    break
+        return continuation_logprobs, is_greedy
 
     @staticmethod
     def modify_gen_kwargs(kwargs: dict) -> dict:


### PR DESCRIPTION
need to verify why the accuracy is different between sglang and vllm

test sglang with 
```
CUDA_VISIBLE_DEVICES=2,3,4,5 lm_eval --model sglang --model_args pretrained=Qwen/Qwen2-1.5B-Instruct,tp_size=4,dtype=auto,dp_size=1,max_model_len=8000,chunked_prefill_size=1000 --tasks arithmetic --batch_size auto:4
```
output
```
|    Tasks     |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|--------------|------:|------|-----:|------|---|-----:|---|-----:|
|arithmetic_1dc|      1|none  |     0|acc   |↑  |0.0000|±  |0.0000|
|arithmetic_2da|      1|none  |     0|acc   |↑  |0.0015|±  |0.0009|
|arithmetic_2dm|      1|none  |     0|acc   |↑  |0.0030|±  |0.0012|
|arithmetic_2ds|      1|none  |     0|acc   |↑  |0.0000|±  |0.0000|
|arithmetic_3da|      1|none  |     0|acc   |↑  |0.0000|±  |0.0000|
|arithmetic_3ds|      1|none  |     0|acc   |↑  |0.0000|±  |0.0000|
|arithmetic_4da|      1|none  |     0|acc   |↑  |0.0000|±  |0.0000|
|arithmetic_4ds|      1|none  |     0|acc   |↑  |0.0000|±  |0.0000|
|arithmetic_5da|      1|none  |     0|acc   |↑  |0.0000|±  |0.0000|
|arithmetic_5ds|      1|none  |     0|acc   |↑  |0.0000|±  |0.0000|
```

vs vllm

```
lm_eval --model vllm     --model_args pretrained=Qwen/Qwen2-1.5B-Instruct,tensor_parallel_size=4,dtype=auto,gpu_memory_utilization=0.8,data_parallel_size=1,max_model_len=8000,enable_chunked_prefill=True    --tasks arithmetic     --batch_size auto:4
```
output
```
|    Tasks     |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|--------------|------:|------|-----:|------|---|-----:|---|-----:|
|arithmetic_1dc|      1|none  |     0|acc   |↑  |0.0000|±  |0.0000|
|arithmetic_2da|      1|none  |     0|acc   |↑  |0.0035|±  |0.0013|
|arithmetic_2dm|      1|none  |     0|acc   |↑  |0.0055|±  |0.0017|
|arithmetic_2ds|      1|none  |     0|acc   |↑  |0.0010|±  |0.0007|
|arithmetic_3da|      1|none  |     0|acc   |↑  |0.0000|±  |0.0000|
|arithmetic_3ds|      1|none  |     0|acc   |↑  |0.0000|±  |0.0000|
|arithmetic_4da|      1|none  |     0|acc   |↑  |0.0000|±  |0.0000|
|arithmetic_4ds|      1|none  |     0|acc   |↑  |0.0000|±  |0.0000|
|arithmetic_5da|      1|none  |     0|acc   |↑  |0.0000|±  |0.0000|
|arithmetic_5ds|      1|none  |     0|acc   |↑  |0.0000|±  |0.0000|
```